### PR TITLE
28 wrong typing for the advanceddjangofilterconnectionfield constructor

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@ per-file-ignores =
     test_filterset.py:N802
     filters.py:A003
     0001_initial.py:D100,D101,D104
-ignore = ANN002,ANN003,ANN101,ANN102,D106,D107
+ignore = ANN002,ANN003,ANN401,ANN101,ANN102,D106,D107
 
 import-order-style = pycharm
 dictionaries=en_US,python,technical,django

--- a/graphene_django_filter/connection_field.py
+++ b/graphene_django_filter/connection_field.py
@@ -4,7 +4,7 @@ Use the `AdvancedDjangoFilterConnectionField` class from this
 module instead of the `DjangoFilterConnectionField` from graphene-django.
 """
 
-from typing import Any, Dict, Iterable, Optional, Type
+from typing import Any, Callable, Dict, Iterable, Optional, Type, Union
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -24,7 +24,7 @@ class AdvancedDjangoFilterConnectionField(DjangoFilterConnectionField):
 
     def __init__(
         self,
-        type: Type[DjangoObjectType],
+        type: Union[Type[DjangoObjectType], Callable[[], Type[DjangoObjectType]], str],
         fields: Optional[Dict[str, list]] = None,
         order_by: Any = None,
         extra_filter_meta: Optional[dict] = None,


### PR DESCRIPTION
Close #28 and fix the previous build lint problem.