### PR TITLE
Revert the version back to original

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphene-django-filter"
-version = "0.6.5"
+version = "0.6.4"
 description = "Advanced filters for Graphene"
 authors = ["devind-team <team@devind.ru>"]
 license = "MIT"


### PR DESCRIPTION
Didn't know we were using `python semantic release`, so I had manually updated the version. Reverting it back