### PR TITLE
fix: fix python semantic version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Semantic Release
-        uses: relekang/python-semantic-release@master
+        uses: relekang/python-semantic-release@v7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           repository_username: __token__


### PR DESCRIPTION
Moving python semantic releaser version to v7 due to [this](https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#github-action-no-longer-publishes-artifacts-to-pypi-or-github-releases)